### PR TITLE
Support for extracting request body

### DIFF
--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -242,18 +242,18 @@ swsProcessor.prototype.collectRequestResponseData = function (res) {
     }
 
     // Express parameters: req.param and req.query
-    if ("params" in req) {
+    if (req.hasOwnProperty("params")) {
         rrr.http.request.params = {};
-        for(var pname in req.params ){
-            rrr.http.request.params[pname] = swsUtil.swsStringValue(req.params[pname]);
-        }
+        swsUtil.swsStringRecursive(rrr.http.request.params, req.params);
     }
 
-    if ("query" in req) {
+    if (req.hasOwnProperty("query")) {
         rrr.http.request.query = {};
-        for(var pname in req.query ){
-            rrr.http.request.query[pname] = swsUtil.swsStringValue(req.query[pname]);
-        }
+        swsUtil.swsStringRecursive(rrr.http.request.query, req.query);
+    }
+
+    if (req.hasOwnProperty("body")) {
+        swsUtil.swsStringRecursive(rrr.http.request.body, req.body);
     }
 
     return rrr;

--- a/lib/swsUtil.js
+++ b/lib/swsUtil.js
@@ -185,6 +185,7 @@ module.exports.swsMetrics = {
 
 // ////////////////////////////////////////////////////////////////////// //
 
+
 // returns string value of argument, depending on typeof
 module.exports.swsStringValue = function (val) {
     switch( typeof val ){
@@ -204,6 +205,19 @@ module.exports.swsStringValue = function (val) {
     }
     return '';
 };
+
+// returns object key values as string recursively
+module.exports.swsStringRecursive = function (output, val) {
+    if (typeof val === "object" && !Array.isArray(val)) {
+        for (var key in val) {
+            output[key] = this.swsStringRecursive(output[key], val[key]);
+        }
+    } else {
+        output = this.swsStringValue(val);
+    }
+
+    return output;
+}
 
 // recursively cast properties of nested objects to strings
 module.exports.swsCastStringR = function (val) {


### PR DESCRIPTION
Added request body to be visible through the UI, this is very useful when trying to debug requests that got errors.
Also changed the `params`, `query` and `body` from the request to be parsed recursively.