### PR TITLE
Fix getting content-length from response header

### DIFF
--- a/lib/swsCoreStats.js
+++ b/lib/swsCoreStats.js
@@ -208,12 +208,13 @@ swsCoreStats.prototype.countResponse = function (res) {
 
     // TODO move all this to Processor, so it'll be in single place
 
-    if ("_contentLength" in res){
+
+    if ("_contentLength" in res && res['_contentLength'] !== null ){
         resContentLength = res['_contentLength'];
     }else{
         // Try header
-        if(res.hasHeader('content-length')) {
-            resContentLength = res.getHeader('content-length');
+        if(res.getHeader('content-length') !==null ) {
+            resContentLength = parseInt(res.getHeader('content-length'));
         }
     }
 


### PR DESCRIPTION
If the _contentLength attribute is empty, domino affect on other components is observed - such as Last Errors and Errors and other tabs.. 

To fix.. check if _contentLength is not empty, if it is, check the headers