### PR TITLE
Allow to expose the stats as prometheus format

### DIFF
--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -372,5 +372,10 @@ module.exports = {
     // Returns object with collected statistics
     getCoreStats: function() {
         return processor.getStats();
+    },
+    
+    // Allow get stats as prometheus format
+    getPromStats: function() {
+        return promClient.register.metrics();
     }
 };


### PR DESCRIPTION
Ask if it is possible to expose a function that will allow to get the stats as Prometheus format though the code (api) like this:
```javascript
swStats.getPromStats();
```