### PR TITLE
Expose prom-client to be used by a business service

### DIFF
--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -377,5 +377,10 @@ module.exports = {
     // Allow get stats as prometheus format
     getPromStats: function() {
         return promClient.register.metrics();
+    },
+
+    // Expose promClient to allow for custom metrics by application
+    getPromClient: function () {
+        return promClient;
     }
 };


### PR DESCRIPTION
This addresses issue #61 

This change allows a business service to use the same prom-client instance to push custom metrics to the same endpoint.