### PR TITLE
Koa integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,20 +103,16 @@ app.use(swStats.getMiddleware({swaggerSpec:apiSpec}));
 
 #### Koa
 
-Some modifications are necessary: `qs` for nested query string parsing (you can also use [`koa-qs`](https://github.com/koajs/qs) middleware), and setting some object keys. Then [`express-to-koa`](https://github.com/kaelzhang/express-to-koa) can be used which is just a simple `Promise` wrapper.
+[`express-to-koa`](https://github.com/kaelzhang/express-to-koa) can be used which is just a simple `Promise` wrapper.
 
 ```javascript
 var swStats = require('swagger-stats');
 var apiSpec = require('swagger.json');
-var qs = require('qs');
 var e2k = require('express-to-koa');
 
 function configureMiddleware(config = { swaggerSpec:apiSpec }) {
     const middleware = e2k(swStats.getMiddleware(config));
     return async function swaggerStats(appCtx, next) {
-        appCtx.req.originalUrl = appCtx.request.originalUrl;
-        appCtx.res.req = appCtx.req;
-        appCtx.req.query = qs.parse(appCtx.request.query);
         await middleware(appCtx, next);
     };
 }

--- a/README.md
+++ b/README.md
@@ -93,13 +93,38 @@ npm install swagger-stats --save
 
 ### Enable swagger-stats middleware in your app
 
+#### Express
+
 ```javascript
 var swStats = require('swagger-stats');
 var apiSpec = require('swagger.json');
 app.use(swStats.getMiddleware({swaggerSpec:apiSpec}));
 ```
 
-See `/examples` for sample apps 
+#### Koa
+
+Some modifications are necessary: `qs` for nested query string parsing (you can also use [`koa-qs`](https://github.com/koajs/qs) middleware), and setting some object keys. Then [`express-to-koa`](https://github.com/kaelzhang/express-to-koa) can be used which is just a simple `Promise` wrapper.
+
+```javascript
+var swStats = require('swagger-stats');
+var apiSpec = require('swagger.json');
+var qs = require('qs');
+var e2k = require('express-to-koa');
+
+function configureMiddleware(config = { swaggerSpec:apiSpec }) {
+    const middleware = e2k(swStats.getMiddleware(config));
+    return async function swaggerStats(appCtx, next) {
+        appCtx.req.originalUrl = appCtx.request.originalUrl;
+        appCtx.res.req = appCtx.req;
+        appCtx.req.query = qs.parse(appCtx.request.query);
+        await middleware(appCtx, next);
+    };
+}
+
+app.use(configureMiddleware());
+```
+
+See `/examples` for sample apps
 
 ### Get Statistics with API
 

--- a/README.md
+++ b/README.md
@@ -109,15 +109,7 @@ app.use(swStats.getMiddleware({swaggerSpec:apiSpec}));
 var swStats = require('swagger-stats');
 var apiSpec = require('swagger.json');
 var e2k = require('express-to-koa');
-
-function configureMiddleware(config = { swaggerSpec:apiSpec }) {
-    const middleware = e2k(swStats.getMiddleware(config));
-    return async function swaggerStats(appCtx, next) {
-        await middleware(appCtx, next);
-    };
-}
-
-app.use(configureMiddleware());
+app.use(e2k(swStats.getMiddleware({ swaggerSpec:apiSpec })));
 ```
 
 See `/examples` for sample apps

--- a/lib/swsAPIStats.js
+++ b/lib/swsAPIStats.js
@@ -407,7 +407,7 @@ swsAPIStats.prototype.countParametersStats = function (path, method, req, res) {
                     param.hits++;
                     break;
                 case "query":
-                    if( ('query' in req) && (pname in req.sws.query) ){
+                    if( ('query' in req.sws) && (pname in req.sws.query) ){
                         param.hits++;
                     }else if(isRrequired){
                         param.misses++;
@@ -445,7 +445,7 @@ swsAPIStats.prototype.getApiOpParameterValues = function (path, method, req, res
                     break;
 
                 case "query":
-                    if(('query' in req) && (pname in req.sws.query)) {
+                    if(('query' in req.sws) && (pname in req.sws.query)) {
                         paramValues[pname] = swsUtil.swsStringValue(req.sws.query[pname]);
                     }
                     break;

--- a/lib/swsAPIStats.js
+++ b/lib/swsAPIStats.js
@@ -320,7 +320,7 @@ swsAPIStats.prototype.extractPathParams = function (matchResult,keys) {
 // Try to match request to API to known API definition
 swsAPIStats.prototype.matchRequest = function (req) {
 
-    var url = req.originalUrl;
+    var url = req.sws.originalUrl;
 
     req.sws.match = false;  // No match by default
 
@@ -407,7 +407,7 @@ swsAPIStats.prototype.countParametersStats = function (path, method, req, res) {
                     param.hits++;
                     break;
                 case "query":
-                    if( ('query' in req) && (pname in req.query) ){
+                    if( ('query' in req) && (pname in req.sws.query) ){
                         param.hits++;
                     }else if(isRrequired){
                         param.misses++;
@@ -445,8 +445,8 @@ swsAPIStats.prototype.getApiOpParameterValues = function (path, method, req, res
                     break;
 
                 case "query":
-                    if(('query' in req) && (pname in req.query)) {
-                        paramValues[pname] = swsUtil.swsStringValue(req.query[pname]);
+                    if(('query' in req) && (pname in req.sws.query)) {
+                        paramValues[pname] = swsUtil.swsStringValue(req.sws.query[pname]);
                     }
                     break;
             }
@@ -470,7 +470,7 @@ swsAPIStats.prototype.countRequest = function (req, res) {
 // Count finished response
 swsAPIStats.prototype.countResponse = function (res) {
 
-    var req = res.req;
+    var req = res._swsReq;
     var codeclass = swsUtil.getStatusCodeClass(res.statusCode);
 
     // Only intersted in updating stats here

--- a/lib/swsCoreStats.js
+++ b/lib/swsCoreStats.js
@@ -197,14 +197,14 @@ swsCoreStats.prototype.countRequest = function (req, res) {
 // Count finished response
 swsCoreStats.prototype.countResponse = function (res) {
 
-    var req = res.req;
+    var req = res._swsReq;
 
     // Defaults
     var startts = 0;
     var duration = 0;
     var resContentLength = 0;
     var timelineid = 0;
-    var path = req.originalUrl;
+    var path = req.sws.originalUrl;
 
     // TODO move all this to Processor, so it'll be in single place
 

--- a/lib/swsErrors.js
+++ b/lib/swsErrors.js
@@ -37,9 +37,9 @@ swsErrors.prototype.countResponse = function (res) {
     this.statuscode_count[res.statusCode]++;
 
     if(res.statusCode==404){
-        this.countPathHit(res.req.originalUrl,this.top_not_found);
+        this.countPathHit(res._swsReq.sws.originalUrl,this.top_not_found);
     }else if(res.statusCode==500){
-        this.countPathHit(res.req.originalUrl,this.top_server_error);
+        this.countPathHit(res._swsReq.sws.originalUrl,this.top_server_error);
     }
 
 };

--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -339,6 +339,8 @@ module.exports = {
 
         return function trackingMiddleware(req, res, next) {
 
+            res._swsReq = req;
+
             // Respond to requests handled by swagger-stats
             // swagger-stats requests will not be counted in statistics
             if(req.url.startsWith(pathStats)) {
@@ -379,7 +381,7 @@ module.exports = {
     getCoreStats: function() {
         return processor.getStats();
     },
-    
+
     // Allow get stats as prometheus format
     getPromStats: function() {
         return promClient.register.metrics();

--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -6,6 +6,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var debug = require('debug')('sws:interface');
 var promClient = require("prom-client");
 var basicAuth = require("basic-auth");
@@ -15,6 +16,7 @@ const uuidv1 = require('uuid/v1');
 var swsUtil = require('./swsUtil');
 var swsProcessor = require('./swsProcessor');
 var send = require('send');
+var qs = require('qs');
 
 // API data processor
 var processor = null;
@@ -286,7 +288,7 @@ function processGetStats(req,res){
             res.setHeader('x-sws-authenticated','true');
         }
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify(processor.getStats(req.query)));
+        res.end(JSON.stringify(processor.getStats(req.sws.query)));
     });
 
     /*
@@ -340,6 +342,8 @@ module.exports = {
         return function trackingMiddleware(req, res, next) {
 
             res._swsReq = req;
+            req.sws = {};
+            req.sws.query = qs.parse(url.parse(req.url).query);
 
             // Respond to requests handled by swagger-stats
             // swagger-stats requests will not be counted in statistics

--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -14,6 +14,7 @@ const uuidv1 = require('uuid/v1');
 
 var swsUtil = require('./swsUtil');
 var swsProcessor = require('./swsProcessor');
+var send = require('send');
 
 // API data processor
 var processor = null;
@@ -174,17 +175,20 @@ function processAuth(req,res,useWWWAuth) {
 
                     }else{
                         msg = 'Invalid credentials';
-                        res.status(403).end(msg);
+                        res.statusCode = 403;
+                        res.end(msg);
                         return resolve(false);
                     }
                 });
 
             }else{
-                res.status(403).end(msg);
+                res.statusCode = 403;
+                res.end(msg);
                 return resolve(false);
             }
         }else{
-            res.status(403).end(msg);
+            res.statusCode = 403;
+            res.end(msg);
             return resolve(false);
         }
 
@@ -263,7 +267,8 @@ function processLogout(req,res){
         }
     }
 
-    res.status(200).end('Logged out');
+    res.statusCode = 200;
+    res.end('Logged out');
 }
 
 
@@ -276,11 +281,12 @@ function processGetStats(req,res){
         if(!authResult){
             return;
         }
-        res.status(200);
+        res.statusCode = 200;
         if(('sws-auth' in req) && req['sws-auth']){
             res.setHeader('x-sws-authenticated','true');
         }
-        res.json( processor.getStats( req.query ) );
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(processor.getStats(req.query)));
     });
 
     /*
@@ -305,7 +311,8 @@ function processGetMetrics(req,res){
         if(!authResult){
             return;
         }
-        res.status(200).set('Content-Type', 'text/plain');
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'text/plain');
         res.end(promClient.register.metrics());
     });
 
@@ -342,7 +349,9 @@ module.exports = {
                 processLogout(req,res);
                 return;
             }else if(req.url.startsWith(pathUI) ){
-                res.status(200).send(uiMarkup);
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/html');
+                res.end(uiMarkup);
                 return;
             }else if(req.url.startsWith(pathDist)) {
                 var fileName = req.url.replace(pathDist+'/','');
@@ -354,11 +363,8 @@ module.exports = {
                     dotfiles: 'deny'
                     // TODO Caching
                 };
-                res.sendFile(fileName, options, function (err) {
-                    if (err) {
-                        debug('unable to send file: %s',fileName);
-                    }
-                });
+                res.setHeader('Content-Type', send.mime.lookup(path.basename(fileName)));
+                send(req, fileName, options).pipe(res);
                 return;
             }
 

--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -287,7 +287,7 @@ swsProcessor.prototype.getPort = function (req ) {
 
 swsProcessor.prototype.getRemoteRealIP = function (req ) {
     var remoteaddress = null;
-    var xfwd = req.header('x-forwarded-for');
+    var xfwd = req.headers['x-forwarded-for'];
     if (xfwd) {
         var fwdaddrs = xfwd.split(','); // Could be "client IP, proxy 1 IP, proxy 2 IP"
         remoteaddress = fwdaddrs[0];

--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -7,7 +7,6 @@
 
 var os = require('os');
 var util = require('util');
-var url = require('url');
 
 var debug = require('debug')('sws:processor');
 var debugrrr = require('debug')('sws:rrr');
@@ -15,7 +14,6 @@ var debugrrr = require('debug')('sws:rrr');
 var swsUtil = require('./swsUtil');
 var pathToRegexp = require('path-to-regexp');
 var moment = require('moment');
-var qs = require('qs');
 
 var swsReqResStats = require('./swsReqResStats');
 var swsCoreStats = require('./swsCoreStats');
@@ -303,7 +301,7 @@ swsProcessor.prototype.getRemoteRealIP = function (req ) {
 swsProcessor.prototype.processRequest = function (req, res) {
 
     // Placeholder for sws-specific attributes
-    req.sws = {};
+    req.sws = req.sws || {};
 
     // Setup sws props and pass to stats processors
     var ts = Date.now();
@@ -314,7 +312,6 @@ swsProcessor.prototype.processRequest = function (req, res) {
     }
 
     req.sws.originalUrl = req.originalUrl || req.url;
-    req.sws.query = qs.parse(url.parse(req.url).query);
     req.sws.track = true;
     req.sws.startts = ts;
     req.sws.timelineid = Math.floor( ts/ this.timeline.settings.bucket_duration );

--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -7,6 +7,7 @@
 
 var os = require('os');
 var util = require('util');
+var url = require('url');
 
 var debug = require('debug')('sws:processor');
 var debugrrr = require('debug')('sws:rrr');
@@ -14,6 +15,7 @@ var debugrrr = require('debug')('sws:rrr');
 var swsUtil = require('./swsUtil');
 var pathToRegexp = require('path-to-regexp');
 var moment = require('moment');
+var qs = require('qs');
 
 var swsReqResStats = require('./swsReqResStats');
 var swsCoreStats = require('./swsCoreStats');
@@ -165,14 +167,14 @@ swsProcessor.prototype.tick = function (that) {
 // TODO Support option to add arbitrary extra properties to sws request/response record
 swsProcessor.prototype.collectRequestResponseData = function (res) {
 
-    var req = res.req;
+    var req = res._swsReq;
 
     var codeclass = swsUtil.getStatusCodeClass(res.statusCode);
 
     var rrr = {
-        'path': req.originalUrl,
+        'path': req.sws.originalUrl,
         'method': req.method,
-        'query' : req.method + ' ' + req.originalUrl,
+        'query' : req.method + ' ' + req.sws.originalUrl,
         'startts': 0,
         'endts': 0,
         'responsetime': 0,
@@ -248,15 +250,15 @@ swsProcessor.prototype.collectRequestResponseData = function (res) {
 
     }
 
-    // Express parameters: req.param and req.query
+    // Express/Koa parameters: req.params (router) and req.body (body parser)
     if (req.hasOwnProperty("params")) {
         rrr.http.request.params = {};
         swsUtil.swsStringRecursive(rrr.http.request.params, req.params);
     }
 
-    if (req.hasOwnProperty("query")) {
+    if (req.sws && req.sws.hasOwnProperty("query")) {
         rrr.http.request.query = {};
-        swsUtil.swsStringRecursive(rrr.http.request.query, req.query);
+        swsUtil.swsStringRecursive(rrr.http.request.query, req.sws.query);
     }
 
     if (req.hasOwnProperty("body")) {
@@ -311,6 +313,8 @@ swsProcessor.prototype.processRequest = function (req, res) {
         reqContentLength = parseInt(req.headers['content-length']);
     }
 
+    req.sws.originalUrl = req.originalUrl || req.url;
+    req.sws.query = qs.parse(url.parse(req.url).query);
     req.sws.track = true;
     req.sws.startts = ts;
     req.sws.timelineid = Math.floor( ts/ this.timeline.settings.bucket_duration );
@@ -340,7 +344,7 @@ swsProcessor.prototype.processRequest = function (req, res) {
 
 swsProcessor.prototype.processResponse = function (res) {
 
-    var req = res.req;
+    var req = res._swsReq;
 
     // Capture route path for the request, if set by router
     var route_path = '';
@@ -351,9 +355,9 @@ swsProcessor.prototype.processResponse = function (res) {
     }
 
     // If request was not matched to Swagger API, set API path:
-    // Use route_path, if exist; if not, use originalUrl
+    // Use route_path, if exist; if not, use sws.originalUrl
     if(!('api_path' in req.sws)){
-        req.sws.api_path = (route_path!=''?route_path:req.originalUrl);
+        req.sws.api_path = (route_path!=''?route_path:req.sws.originalUrl);
     }
 
     // Pass through Core Statistics

--- a/lib/swsTimeline.js
+++ b/lib/swsTimeline.js
@@ -158,7 +158,7 @@ swsTimeline.prototype.countRequest = function (req, res) {
 // Count finished response
 swsTimeline.prototype.countResponse = function (res) {
 
-    var req = res.req;
+    var req = res._swsReq;
 
     // Update timeline stats
     this.getTimelineBucket(req.sws.timelineid).stats.countResponse(

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,6 +670,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         }
       }
     },
@@ -11984,9 +11990,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -12307,6 +12313,11 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2275,8 +2275,7 @@
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -2444,8 +2443,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
       "version": "1.3.62",
@@ -2462,8 +2460,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "0.1.5",
@@ -2620,8 +2617,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2681,8 +2677,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -2917,6 +2912,27 @@
               "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
               "dev": true
             }
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
           }
         },
         "statuses": {
@@ -3538,8 +3554,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-access": {
       "version": "1.0.1",
@@ -5389,8 +5404,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -10781,7 +10795,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -12551,10 +12564,9 @@
       }
     },
     "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "dev": true,
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -12563,28 +12575,60 @@
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
           }
         },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
         }
       }
     },
@@ -12625,6 +12669,44 @@
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.2",
         "send": "0.16.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
+        }
       }
     },
     "set-immediate-shim": {
@@ -13115,8 +13197,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-consume": {
       "version": "0.1.1",
@@ -13866,6 +13947,11 @@
       "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
       "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
       "dev": true
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "natives": "^1.1.6",
     "path-to-regexp": "^2.1.0",
     "prom-client": "^11.0.0",
+    "qs": "^6.7.0",
     "request": "^2.85.0",
     "send": "^0.17.1",
     "uuid": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "path-to-regexp": "^2.1.0",
     "prom-client": "^11.0.0",
     "request": "^2.85.0",
+    "send": "^0.17.1",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #67. Uses as little server (Express) specific functions as possible.

- Use own query string handling via `qs`.
- Don't use `res.req`, replace with `res._swsReq`
- Don't use `req.originalUrl`, replace with `req.sws.originalUrl`
- Rewrite Express-specific response methods to Node-native, using `send` for sending files.
- Keeps `req.body` and `req.params` - these belong to the body parser and router outside.
- Provide Koa example in README

Risks & drawbacks:
- 2 new dependencies, `send` and `qs` - these are already in the `node_modules` tree for most deployments.
- Query string is re-parsed for each request even if Express is used. (Koa does standard query string parsing, not supporting object fields)
- Maybe `send` error handling is missing?

Please test with Elastic because I can't at the moment.