### PR TITLE
decrease inflight request timer if request times out

### DIFF
--- a/lib/swsCoreStats.js
+++ b/lib/swsCoreStats.js
@@ -191,6 +191,9 @@ swsCoreStats.prototype.countRequest = function (req, res) {
     // Update prom-client metrics
     this.promClientMetrics.api_all_request_total.inc();
     this.promClientMetrics.api_all_request_in_processing_total.inc();
+    req.sws.inflightTimer = setTimeout(function() {
+        this.promClientMetrics.api_all_request_in_processing_total.dec();
+    }.bind(this), 250000);
 };
 
 
@@ -227,6 +230,7 @@ swsCoreStats.prototype.countResponse = function (res) {
         req['sws'].duration = duration;
         req['sws'].res_clength = resContentLength;
         path = req['sws'].api_path;
+        clearTimeout(req.sws.inflightTimer);
     }
 
     // Determine status code type


### PR DESCRIPTION
I have tested this in production. With this, the inflight request counter is decreased after a 250s timeout (if there is never a response for the request, it wouldn't get stuck).