### PR TITLE
add `stop` method to swsProcessor and swsInterface

### DIFF
--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -394,5 +394,10 @@ module.exports = {
     // Expose promClient to allow for custom metrics by application
     getPromClient: function () {
         return promClient;
+    },
+
+    // Stop the processor so that Node.js can exit
+    stop: function () {
+        processor.stop();
     }
 };

--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -88,7 +88,14 @@ swsProcessor.prototype.init = function (swsOptions) {
     this.elasticsearchEmitter.initialize(swsOptions);
 
     // Start tick
-    setInterval(this.tick, 200, this);
+    this.timer = setInterval(this.tick, 200, this);
+};
+
+// Stop
+swsProcessor.prototype.stop = function () {
+
+    clearInterval(this.timer);
+
 };
 
 swsProcessor.prototype.processOptions = function (swsOptions) {

--- a/test/000_baseline.js
+++ b/test/000_baseline.js
@@ -498,6 +498,12 @@ setImmediate(function() {
 
         });
 
+        describe('Stop', function () {
+            it('should stop', function (done) {
+                swsInterface.stop();
+            });
+        });
+
     });
 
     run();


### PR DESCRIPTION
When adding swagger-stats in an existing application, the test suite will currently hang.

This helps test environment cleanly exit by calling the `stop` method on swagger-stats.