### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/swsProcessor.js
+++ b/lib/swsProcessor.js
@@ -173,11 +173,9 @@ class SwsProcessor {
         }
 
         // Response Headers
-        if ("_headers" in res){
-            rrr.http.response.headers = {};
-            for(var hdr in res['_headers']){
-                rrr.http.response.headers[hdr] = res['_headers'][hdr];
-            }
+        var responseHeaders = res.getHeaders();
+        if (responseHeaders){
+            rrr.http.response.headers = responseHeaders;
         }
 
         // Additional details from collected info per request / response pair


### PR DESCRIPTION
I was seeing a deprecation warning on every single request. This is due to the following code in `swsProcessor.js`:
```
// Response Headers
        if ("_headers" in res){
            rrr.http.response.headers = {};
            for(var hdr in res['_headers']){
                rrr.http.response.headers[hdr] = res['_headers'][hdr];
            }
        }
```
See more: https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames

The fix is to not access `_headers` directly. Instead, nodejs provides a few methods such as res.getHeaders() which is what I did in this PR.

Please let me know if you have any questions.