### PR TITLE
append basePath on setCookie

### DIFF
--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -103,7 +103,7 @@ function processAuth(req,res,useWWWAuth) {
                 // renew it
                 //sessionIDs[sessionIdCookie] = Date.now();
                 storeSessionID(sessionIdCookie);
-                cookies.set('sws-session-id',sessionIdCookie,{path:swsSettings.uriPath,maxAge:swsSettings.sessionMaxAge*1000});
+                cookies.set('sws-session-id',sessionIdCookie,{path:swsSettings.basePath+swsSettings.uriPath,maxAge:swsSettings.sessionMaxAge*1000});
                 // Ok
                 req['sws-auth'] = true;
                 return resolve(true);
@@ -129,7 +129,7 @@ function processAuth(req,res,useWWWAuth) {
                             var sessid = uuidv1();
                             storeSessionID(sessid);
                             // Set session cookie with expiration in 15 min
-                            cookies.set('sws-session-id',sessid,{path:swsSettings.uriPath,maxAge:swsSettings.sessionMaxAge*1000});
+                            cookies.set('sws-session-id',sessid,{path:swsSettings.basePath+swsSettings.uriPath,maxAge:swsSettings.sessionMaxAge*1000});
                         }
 
                         req['sws-auth'] = true;


### PR DESCRIPTION
He was having problems identifying himself, since the path set in the cookie was not correct, he was not taking into account the basePath of the application.

BasePath was included at the time of setting the cookie.