### PR TITLE
Allow passing of hapi specific options

### DIFF
--- a/lib/swsHapi.js
+++ b/lib/swsHapi.js
@@ -58,7 +58,8 @@ class SwsHapi {
             path: swsSettings.pathStats,
             handler: function (request, h) {
                 return processor.getStats(request.raw.req.sws.query);
-            }
+            },
+            options: options.routeOptions
         });
         // Return metrics
         server.route({
@@ -69,7 +70,8 @@ class SwsHapi {
                 response.code(200);
                 response.header('Content-Type', 'text/plain');
                 return response;
-            }
+            },
+            options: options.routeOptions
         });
         // Redirect to ui
         server.route({
@@ -77,7 +79,8 @@ class SwsHapi {
             path: swsSettings.uriPath,
             handler: function (request, h) {
                 return h.redirect(swsSettings.pathUI);
-            }
+            },
+            options: options.routeOptions
         });
         // Return UI
         server.route({
@@ -85,7 +88,8 @@ class SwsHapi {
             path: swsSettings.pathUI,
             handler: function (request, h) {
                 return swsUtil.swsEmbeddedUIMarkup;
-            }
+            },
+            options: options.routeOptions
         });
         // Return Dist
         server.route({
@@ -101,7 +105,8 @@ class SwsHapi {
                 request.raw.res.setHeader('Content-Type', send.mime.lookup(path.basename(fileName)));
                 send(request.raw.req, fileName, options).pipe(request.raw.res);
                 return h.abandon;
-            }
+            },
+            options: options.routeOptions
         });
         // Return UX
         server.route({
@@ -120,7 +125,8 @@ class SwsHapi {
                 request.raw.res.setHeader('Content-Type', send.mime.lookup(path.basename(fileName)));
                 send(request.raw.req, fileName, options).pipe(request.raw.res);
                 return h.abandon;
-            }
+            },
+            options: options.routeOptions
         });
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-stats",
-  "version": "0.95.15",
+  "version": "0.95.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR is a partial answer to #94.

The passes a new _undocumented_ property `routeOptions` that can be passed to the hapi plugin. This allows the user to set whatever hapi-specific route options they'd like, though it does so for ALL implemented routes. There is an opportunity for enhancement of this feature by allowing overrides to specific routes.

I must confess though, I did not implement a new test. Not for lack of trying! But for the life of me, I can't figure out what your testing structure is here. Could you provide some guidance in the CONTRIBUTING.md?