### PR TITLE
Fix question mark character error for path-to-regexp

### DIFF
--- a/lib/swsAPIStats.js
+++ b/lib/swsAPIStats.js
@@ -164,7 +164,7 @@ swsAPIStats.prototype.initialize = function(swsOptions) {
         if( fullExpressPath.indexOf('{') !== -1 ) {
             fullExpressPath = fullExpressPath.replace(/\{/g, ':');
             fullExpressPath = fullExpressPath.replace(/\}/g, '');
-            fullExpressPath = fullExpressPath.replace(/\?/g, '\\?');
+            fullExpressPath = fullExpressPath.replace(/\?(\w+=)/g, '\\?$1');
             re = pathToRegexp(fullExpressPath, keys);
         }
 


### PR DESCRIPTION
When a query strings question mark ( ? ) is present in one path, it must be escaped according to the [path-to-regexp documentation](https://www.npmjs.com/package/path-to-regexp#optional) if it is not used to define an optional parameter.

`When using paths that contain query strings, you need to escape the question mark (?) to ensure it does not flag the parameter as optional.`


Edit: Update regex with `/\?(\w+=)/g` instead of `/\?/g` to insure that the '?' is used for a query string