### PR TITLE
Add Dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+


### PR DESCRIPTION
Enables automated dependency updates via [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates). Some of the dependencies of swagger-stats have security vulnerabilities and enabling Dependabot will help address those and keep them up to date.

For example, the version of json-schema in use has a vulnerability: https://github.com/advisories/GHSA-896r-f27r-55mw