### PR TITLE
Fix fastify deprecation warning

### DIFF
--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -172,8 +172,8 @@ function fastifyPlugin (fastify, opts, done) {
         // TODO Headers
         //let h = Object.getOwnPropertySymbols(reply);
         //let hh = reply[headersSymbol];
-        // Set route_path as reply.context.config.url
-        if(('context' in reply) && ('config' in reply.routeOptions) && ('url' in reply.routeOptions.config)){
+        // Set route_path as reply.routeOptions.config.url
+        if(('routeOptions' in reply) && ('config' in reply.routeOptions) && ('url' in reply.routeOptions.config)){
             request.raw.sws.route_path = reply.routeOptions.config.url;
         }
         done()

--- a/lib/swsInterface.js
+++ b/lib/swsInterface.js
@@ -173,8 +173,8 @@ function fastifyPlugin (fastify, opts, done) {
         //let h = Object.getOwnPropertySymbols(reply);
         //let hh = reply[headersSymbol];
         // Set route_path as reply.context.config.url
-        if(('context' in reply) && ('config' in reply.context) && ('url' in reply.context.config)){
-            request.raw.sws.route_path = reply.context.config.url;
+        if(('context' in reply) && ('config' in reply.routeOptions) && ('url' in reply.routeOptions.config)){
+            request.raw.sws.route_path = reply.routeOptions.config.url;
         }
         done()
     });


### PR DESCRIPTION
# Context

I have a fastify api, that uses swagger-stats. In each request, I get multiple times the following error:
```
[FSTDEP019] FastifyDeprecation: reply.context property access is deprecated. Please use "reply.routeOptions.config" or "reply.routeOptions.schema" instead for accessing Route settings. The "reply.context" will be removed in `fastify@5`.
```

This change fixes the issue & avoid the flood of deprecation warning logs.

